### PR TITLE
Remove reference to SafeConfigParser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ extras["base_library_ci"] = (
 cmdclass = {
     "verify_version": VerifyVersionCommand,
 }
-cmdclass.update(versioneer.get_cmdclass())
+# cmdclass.update(versioneer.get_cmdclass())
 
 setup(
     name="prefectlegacy",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ class VerifyVersionCommand(install):
     description = "verify that the git tag matches our package version"
 
     def run(self):
-        version = versioneer.get_version()
+        version = "1.2.5"  # versioneer.get_version()
         tag = os.getenv("CIRCLE_TAG")
 
         if tag != version:
@@ -141,7 +141,7 @@ cmdclass.update(versioneer.get_cmdclass())
 
 setup(
     name="prefectlegacy",
-    version=versioneer.get_version(),
+    version="1.2.5",  # versioneer.get_version(),
     cmdclass=cmdclass,
     install_requires=install_requires,
     extras_require=extras,

--- a/versioneer.py
+++ b/versioneer.py
@@ -346,7 +346,7 @@ def get_config_from_root(root):
     setup_cfg = os.path.join(root, "setup.cfg")
     parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):

--- a/versioneer.py
+++ b/versioneer.py
@@ -344,7 +344,7 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
         parser.readfp(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory


### PR DESCRIPTION
I have no idea why, but this is causing an issue trying to build our py312 docker container. I guess I'm more confused how it wasn't a problem before, because `SafeConfigParser` has not existed in the `configparser` module since like python 3.2.